### PR TITLE
Feature/28 alterar nome do atributo do ebook de isbn para isbn 13

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,16 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::API
+  before_action :map_isbn_to_isbn13, only: :create
   rescue_from ActiveRecord::RecordNotFound, with: :not_found
 
   private
+
+  def map_isbn_to_isbn13
+    return unless params[:data][:attributes][:isbn].present?
+
+    params[:data][:attributes][:isbn13] = params[:data][:attributes].delete(:isbn)
+  end
 
   def not_found(exception)
     render json: JsonResponses::Errors::NotFound.call(exception), status: :not_found

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,12 +7,16 @@ class ApplicationController < ActionController::API
   private
 
   def map_isbn_to_isbn13
-    return unless params[:data][:attributes][:isbn].present?
+    return unless isbn_present?
 
-    params[:data][:attributes][:isbn13] = params[:data][:attributes].delete(:isbn)
+    Ebooks::IsbnToIsbn13Mapper.call(params)
   end
 
   def not_found(exception)
     render json: JsonResponses::Errors::NotFound.call(exception), status: :not_found
+  end
+
+  def isbn_present?
+    params.dig(:data, :attributes, :isbn).present?
   end
 end

--- a/app/controllers/v1/ebooks_controller.rb
+++ b/app/controllers/v1/ebooks_controller.rb
@@ -25,7 +25,7 @@ module V1
     private
 
     def ebook_params
-      params.require(:data).require(:attributes).permit(:title, :description, :author, :genre, :isbn)
+      params.require(:data).require(:attributes).permit(:title, :description, :author, :genre, :isbn13)
     end
   end
 end

--- a/app/controllers/v2/ebooks_controller.rb
+++ b/app/controllers/v2/ebooks_controller.rb
@@ -25,7 +25,7 @@ module V2
     private
 
     def ebook_params
-      params.require(:data).require(:attributes).permit(:title, :description, :author, :genre, :isbn, :publisher)
+      params.require(:data).require(:attributes).permit(:title, :description, :author, :genre, :isbn13, :publisher)
     end
   end
 end

--- a/app/controllers/v3/ebooks_controller.rb
+++ b/app/controllers/v3/ebooks_controller.rb
@@ -30,7 +30,7 @@ module V3
     private
 
     def ebook_params
-      params.require(:data).require(:attributes).permit(:title, :description, :author, :genre, :isbn, :publisher)
+      params.require(:data).require(:attributes).permit(:title, :description, :author, :genre, :isbn13, :publisher)
     end
   end
 end

--- a/app/serializers/ebook_serializer.rb
+++ b/app/serializers/ebook_serializer.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-class EbookSerializer
-  include JSONAPI::Serializer
-  attributes :title, :description, :author, :genre, :isbn13, :created_at, :updated_at
-end

--- a/app/serializers/ebook_serializer.rb
+++ b/app/serializers/ebook_serializer.rb
@@ -2,5 +2,5 @@
 
 class EbookSerializer
   include JSONAPI::Serializer
-  attributes :title, :description, :author, :genre, :isbn, :created_at, :updated_at
+  attributes :title, :description, :author, :genre, :isbn13, :created_at, :updated_at
 end

--- a/app/serializers/v1/ebooks_serializer.rb
+++ b/app/serializers/v1/ebooks_serializer.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
 module V1
-  class EbooksSerializer < EbookSerializer
+  class EbooksSerializer
+    include JSONAPI::Serializer
+
+    attributes :title, :description, :author, :genre, :isbn, :created_at, :updated_at
+
+    attribute :isbn do |ebook|
+      ebook.isbn13.to_s
+    end
   end
 end

--- a/app/serializers/v2/ebooks_serializer.rb
+++ b/app/serializers/v2/ebooks_serializer.rb
@@ -1,8 +1,13 @@
 # frozen_string_literal: true
 
 module V2
-  class EbooksSerializer < EbookSerializer
+  class EbooksSerializer
     include JSONAPI::Serializer
-    attributes :publisher
+
+    attributes :title, :description, :author, :genre, :publisher, :isbn, :created_at, :updated_at
+
+    attribute :isbn do |ebook|
+      ebook.isbn13.to_s
+    end
   end
 end

--- a/app/serializers/v3/ebooks_serializer.rb
+++ b/app/serializers/v3/ebooks_serializer.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 module V3
-  class EbooksSerializer < EbookSerializer
+  class EbooksSerializer
     include JSONAPI::Serializer
-    attributes :publisher
+
+    attributes :title, :description, :author, :genre, :publisher, :isbn13, :created_at, :updated_at
   end
 end

--- a/app/services/ebooks/isbn_to_isbn13_mapper.rb
+++ b/app/services/ebooks/isbn_to_isbn13_mapper.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Ebooks
+  class IsbnToIsbn13Mapper < ApplicationService
+    def initialize(params)
+      @params = params
+      super
+    end
+
+    def call
+      map_isbn_to_isbn13
+    end
+
+    private
+
+    def map_isbn_to_isbn13
+      return unless (isbn = @params[:data][:attributes].delete(:isbn))
+
+      @params[:data][:attributes][:isbn13] = isbn
+    end
+  end
+end

--- a/db/migrate/20240814124042_rename_isbn_to_isbn13_in_ebooks.rb
+++ b/db/migrate/20240814124042_rename_isbn_to_isbn13_in_ebooks.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RenameIsbnToIsbn13InEbooks < ActiveRecord::Migration[7.1]
+  def change
+    rename_column :ebooks, :isbn, :isbn13
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 20_240_801_214_040) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_14_124042) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,9 +19,10 @@ ActiveRecord::Schema[7.1].define(version: 20_240_801_214_040) do
     t.text "description"
     t.string "author"
     t.string "genre"
-    t.string "isbn"
+    t.string "isbn13"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "publisher"
   end
+
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,7 +9,7 @@ Ebook.destroy_all
     title: FFaker::Book.title,
     author: FFaker::Book.author,
     genre: FFaker::Book.genre,
-    isbn: FFaker::Book.isbn,
+    isbn13: FFaker::Book.isbn,
     description: FFaker::Lorem.paragraph
   )
 end

--- a/spec/requests/v1/ebooks_spec.rb
+++ b/spec/requests/v1/ebooks_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "V1::Ebooks", type: :request do
         title: FFaker::Book.title,
         author: FFaker::Book.author,
         genre: FFaker::Book.genre,
-        isbn: FFaker::Book.isbn,
+        isbn13: FFaker::Book.isbn,
         description: FFaker::Lorem.paragraph
       )
     end
@@ -40,7 +40,7 @@ RSpec.describe "V1::Ebooks", type: :request do
             "author" => ebook.author,
             "description" => ebook.description,
             "genre" => ebook.genre,
-            "isbn" => ebook.isbn,
+            "isbn" => ebook.isbn13,
             "created_at" => be_present,
             "updated_at" => be_present
           )

--- a/spec/requests/v2/ebooks_spec.rb
+++ b/spec/requests/v2/ebooks_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "V2::Ebooks", type: :request do
         title: FFaker::Book.title,
         author: FFaker::Book.author,
         genre: FFaker::Book.genre,
-        isbn: FFaker::Book.isbn,
+        isbn13: FFaker::Book.isbn,
         description: FFaker::Lorem.paragraph,
         publisher: FFaker::Company.name
       )
@@ -41,7 +41,7 @@ RSpec.describe "V2::Ebooks", type: :request do
             "author" => ebook.author,
             "description" => ebook.description,
             "genre" => ebook.genre,
-            "isbn" => ebook.isbn,
+            "isbn" => ebook.isbn13,
             "publisher" => ebook.publisher,
             "created_at" => be_present,
             "updated_at" => be_present

--- a/spec/requests/v3/ebooks_spec.rb
+++ b/spec/requests/v3/ebooks_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "V3::Ebooks", type: :request do
         title: FFaker::Book.title,
         author: FFaker::Book.author,
         genre: FFaker::Book.genre,
-        isbn: FFaker::Book.isbn,
+        isbn13: FFaker::Book.isbn,
         description: FFaker::Lorem.paragraph,
         publisher: FFaker::Company.name
       )
@@ -57,7 +57,7 @@ RSpec.describe "V3::Ebooks", type: :request do
             "author" => ebook.author,
             "description" => ebook.description,
             "genre" => ebook.genre,
-            "isbn" => ebook.isbn,
+            "isbn13" => ebook.isbn13,
             "publisher" => ebook.publisher,
             "created_at" => be_present,
             "updated_at" => be_present
@@ -95,7 +95,7 @@ RSpec.describe "V3::Ebooks", type: :request do
             title: FFaker::Book.title,
             author: FFaker::Book.author,
             genre: FFaker::Book.genre,
-            isbn: FFaker::Book.isbn,
+            isbn13: FFaker::Book.isbn,
             description: FFaker::Lorem.paragraph,
             publisher: FFaker::Company.name
           }
@@ -110,7 +110,7 @@ RSpec.describe "V3::Ebooks", type: :request do
           attributes: {
             author: FFaker::Book.author,
             genre: FFaker::Book.genre,
-            isbn: FFaker::Book.isbn,
+            isbn13: FFaker::Book.isbn,
             description: FFaker::Lorem.paragraph,
             publisher: FFaker::Company.name
           }
@@ -131,7 +131,7 @@ RSpec.describe "V3::Ebooks", type: :request do
             "description" => be_present,
             "author" => be_present,
             "genre" => be_present,
-            "isbn" => be_present,
+            "isbn13" => be_present,
             "publisher" => be_present,
             "created_at" => be_present,
             "updated_at" => be_present

--- a/spec/services/ebooks/isbn_to_isbn13_mapper_spec.rb
+++ b/spec/services/ebooks/isbn_to_isbn13_mapper_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Ebooks::IsbnToIsbn13Mapper, type: :service do
+  describe "#call" do
+    let(:params) do
+      {
+        data: {
+          attributes: {
+            isbn: "1234567890"
+          }
+        }
+      }
+    end
+
+    subject { described_class.call(params) }
+
+    it "converts isbn to isbn13" do
+      subject
+      expect(params[:data][:attributes][:isbn13]).to eq("1234567890")
+      expect(params[:data][:attributes][:isbn]).to be_nil
+    end
+
+    context "when isbn is not present" do
+      let(:params) do
+        {
+          data: {
+            attributes: {}
+          }
+        }
+      end
+
+      it "does not add isbn13" do
+        subject
+        expect(params[:data][:attributes][:isbn13]).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
História: O cliente da versão 3 da api tem a necessidade de seguir padrões internacionais quanto a isbn. Assim será necessário que ao enviar e receber informações do Ebook esse atributo tenha seu nome correto garantindo a consistência dos dados.

Critério de aceite: O atributo do Ebook deve ser renomeado de `isbn` para `isbn13`.
Ganho para o cliente: Padronização internacional.

Esta feature:
- [ ] #28